### PR TITLE
[FEAT] 글쓰기 페이지 API 연동

### DIFF
--- a/src/components/ExperienceForm.js
+++ b/src/components/ExperienceForm.js
@@ -38,6 +38,7 @@ const ExperienceForm = ({ title, onRemove, onSave}) => {
                         placeholder="제목을 입력하세요"
                         value={exTitle}
                         onChange={handleTitleChange}
+                        required
                     />
                     <div className={styles.characterCount}>
                         {characterCount}자
@@ -51,6 +52,7 @@ const ExperienceForm = ({ title, onRemove, onSave}) => {
                 value={text}
                 onChange={handleTextChange}
                 placeholder="내용"
+                required
 
             />
         </div>

--- a/src/components/ExperienceForm.js
+++ b/src/components/ExperienceForm.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styles from '../styles/Write.module.css';
 
-const ExperienceForm = ({ title, onRemove,onSave}) => {
+const ExperienceForm = ({ title, onRemove, onSave}) => {
    
     const [exTitle,setExTitle] = useState(title);
     const [text, setText] = useState('');
@@ -18,7 +18,6 @@ const ExperienceForm = ({ title, onRemove,onSave}) => {
         onSave({ title: newTitle, content: text }); // 변경된 text를 onSave를 통해 전달
     };
     
-
     const characterCount = text.length;
 
     const handleRemove = () => {

--- a/src/components/ExperienceForm.js
+++ b/src/components/ExperienceForm.js
@@ -1,15 +1,23 @@
 import React, { useState } from 'react';
-
 import styles from '../styles/Write.module.css';
-const ExperienceForm = ({ title, onRemove }) => {
+
+const ExperienceForm = ({ title, onRemove,onSave}) => {
+   
+    const [exTitle,setExTitle] = useState(title);
     const [text, setText] = useState('');
 
     const handleTextChange = event => {
         const newText = event.target.value;
         setText(newText);
+        onSave({ title: exTitle, content: newText }); // 변경된 text를 onSave를 통해 전달
     };
 
-
+    const handleTitleChange = event => {
+        const newTitle = event.target.value;
+        setExTitle(newTitle);
+        onSave({ title: newTitle, content: text }); // 변경된 text를 onSave를 통해 전달
+    };
+    
 
     const characterCount = text.length;
 
@@ -21,15 +29,13 @@ const ExperienceForm = ({ title, onRemove }) => {
         <div className={styles.exContainer}>
             <div className={styles.titleContainer}>
                 <div className={styles.titleCharacterContainer}>
-                    {title !== '' ? (
-                        <div className={styles.title}>{title}</div>
-                    ) : (
-                        <input
-                            className={styles.inputTitle}
-                            type="text"
-                            placeholder="제목을 입력하세요"
-                        />
-                    )}
+                    <input
+                        className={styles.inputTitle}
+                        type="text"
+                        placeholder="제목을 입력하세요"
+                        value={exTitle}
+                        onChange={handleTitleChange}
+                    />
                     <div className={styles.characterCount}>
                         {characterCount}자
                     </div>
@@ -42,6 +48,7 @@ const ExperienceForm = ({ title, onRemove }) => {
                 value={text}
                 onChange={handleTextChange}
                 placeholder="내용"
+
             />
         </div>
     );

--- a/src/components/ExperienceForm.js
+++ b/src/components/ExperienceForm.js
@@ -3,26 +3,30 @@ import styles from '../styles/Write.module.css';
 
 const ExperienceForm = ({ title, onRemove, onSave}) => {
    
+    //expreince의 title과 textarea 내용
     const [exTitle,setExTitle] = useState(title);
     const [text, setText] = useState('');
 
-    const handleTextChange = event => {
-        const newText = event.target.value;
+
+    const handleTextChange = e => {
+        const newText = e.target.value;
         setText(newText);
         onSave({ title: exTitle, content: newText }); // 변경된 text를 onSave를 통해 전달
     };
 
-    const handleTitleChange = event => {
-        const newTitle = event.target.value;
+    const handleTitleChange = e => {
+        const newTitle = e.target.value;
         setExTitle(newTitle);
         onSave({ title: newTitle, content: text }); // 변경된 text를 onSave를 통해 전달
     };
     
-    const characterCount = text.length;
-
-    const handleRemove = () => {
+    const handleRemove = e => {
+        e.preventDefault();
         onRemove(); // 부모 컴포넌트로 삭제 요청 전달
     };
+
+    //text의 길이를 셈
+    const characterCount = text.length;
 
     return (
         <div className={styles.exContainer}>

--- a/src/components/PostForm.js
+++ b/src/components/PostForm.js
@@ -1,16 +1,11 @@
-import React, { useState } from 'react';
 import styles from '../styles/Write.module.css';
 import TagInput from './TagInput';
 
 
-const PostForm = () => {
-    const [title, setTitle] = useState('');
-    const [startDate, setStartDate] = useState('');
-    const [endDate, setEndDate] = useState('');
-    const [jobTags, setJobTags] = useState([]);
-    const [abilityTags, setAbilityTags] = useState([]);
-    const [stackTags, setStackTags] = useState([]);
-
+const PostForm = ({title,setTitle,startDate,setStartDate
+                    ,endDate,setEndDate, jobTags,setJobTags
+                    ,abilityTags,setAbilityTags,stackTags,setStackTags}) => {
+    
     const handleTitleChange = e => {
         setTitle(e.target.value);
     };
@@ -65,7 +60,7 @@ const PostForm = () => {
                 <TagInput
                     tags={abilityTags}
                     setTags={setAbilityTags}
-                    tagType="키워드"
+                    tagType="핵심 역량"
                 />
                 <TagInput
                     tags={stackTags}

--- a/src/components/PostForm.js
+++ b/src/components/PostForm.js
@@ -27,6 +27,7 @@ const PostForm = ({title,setTitle,startDate,setStartDate
                         type="text"
                         value={title}
                         onChange={handleTitleChange}
+                        required
                         placeholder="제목을 입력해주세요"
                     />
                 </div>
@@ -39,6 +40,7 @@ const PostForm = ({title,setTitle,startDate,setStartDate
                                 type="date"
                                 value={startDate}
                                 onChange={handleStartDateChange}
+                                required
                             />
                         </div>
                         <div className={styles.date}>
@@ -47,6 +49,7 @@ const PostForm = ({title,setTitle,startDate,setStartDate
                                 type="date"
                                 value={endDate}
                                 onChange={handleEndDateChange}
+                                required
                             />
                         </div>
                     </div>

--- a/src/components/PostForm.js
+++ b/src/components/PostForm.js
@@ -1,7 +1,6 @@
 import styles from '../styles/Write.module.css';
 import TagInput from './TagInput';
 
-
 const PostForm = ({title,setTitle,startDate,setStartDate
                     ,endDate,setEndDate, jobTags,setJobTags
                     ,abilityTags,setAbilityTags,stackTags,setStackTags}) => {

--- a/src/components/TagInput.js
+++ b/src/components/TagInput.js
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import styles from '../styles/Write.module.css';
 
 const TagInput = ({ tags, setTags, tagType }) => {
+    
     const [tagInput, setTagInput] = useState('');
     const [showTagInput, setShowTagInput] = useState(false);
     const inputRef = useRef(null); // 입력 창에 대한 참조 생성

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -19,10 +19,12 @@ const Home = () => {
     //총 post 수
     const [totalPosts, setTotalPosts] = useState(0);
     
+    //page가 바뀌면 화면을 top으로 이동
     const handlePageChange = (page) => {
         setCurrentPage(page);
         window.scrollTo({ top: 0});
     };
+    
     //최신순, 오래된순 버튼 선택시 set
     const handleOrderClick = (order) => {
         setOrderBy(order);
@@ -59,7 +61,7 @@ const Home = () => {
             setTotalPages(response.data.result.totalPages);
             setTotalPosts(response.data.result.totalPosts);
           } catch (error) {
-            console.error(error);
+                console.error('post 데이터를 가져오는 동안 오류가 발생했습니다.', error);
           }
         };
 

--- a/src/routes/Write.js
+++ b/src/routes/Write.js
@@ -100,7 +100,11 @@ const Write = () => {
         experiences.forEach((experience) => {
             experiencesObj[experience.title] = experience.content;
         });
-
+        // 필드가 비어있는지 확인
+        if (startDate === '' || endDate === '') {
+            alert('기간을 선택해주세요.'); 
+            return;
+        }
         //createPostRequst Dto 형식에 맞춤
         const createPostRequest = {
             title : title,

--- a/src/routes/Write.js
+++ b/src/routes/Write.js
@@ -4,6 +4,8 @@ import PostForm from '../components/PostForm';
 import ExperienceForm from '../components/ExperienceForm';
 import styles from '../styles/Write.module.css';
 import axios from 'axios';
+
+
 const Write = () => {
     const [title, setTitle] = useState('');
     const [startDate, setStartDate] = useState('');
@@ -12,16 +14,30 @@ const Write = () => {
     const [abilityTags, setAbilityTags] = useState([]);
     const [stackTags, setStackTags] = useState([]);
 
-    
-    const fileInput = React.useRef(null);
 
+    /*내용 추가 버튼 show */
     const [showAddButton, setShowAddButton] = useState(true);
     const [experiences, setExperiences] = useState([
         { title: '활동을 하게 된 동기를 기록해주세요.', content: '' },
         { title: '맡은 역할과 수행 내용을 기록해주세요.', content: '' },
         { title: '힘들었던 점이 있었나요? 어떻게 극복하였나요?', content: '' },
         { title: '느낀점 및 배운점을 기록해주세요.', content: '' },
-      ]);
+    ]);
+
+    // ExperienceForm 삭제
+    const handleRemoveExperience = index => {
+        const newExperiences = [...experiences];
+        newExperiences.splice(index, 1);
+        setExperiences(newExperiences);
+    };
+
+
+    //ExperienceForm 추가
+    const handleAddExperience = () => {
+        setExperiences([...experiences, { title: '', content: '' }]);
+        setShowAddButton(true);
+    };
+    
 
     //expereince update
     const handleSaveExperience = (index, experience) => {
@@ -31,16 +47,15 @@ const Write = () => {
     };
 
 
-    const [selectedFiles, setSelectedFiles] = useState([]);
-
+    //전체 form 제출
     const handleSubmit = async (e) => {
         e.preventDefault();
 
-        const tags = 
-            [  
+        //createTagRequest 형식에 맞춤
+        const tags = [  
                 {
-                tagType: 'Job',
-                tagName: jobTags
+                    tagType: 'Job',
+                    tagName: jobTags
                 },
                 {
                     tagType: 'Stack',
@@ -52,36 +67,48 @@ const Write = () => {
                 }
             ];
         
-        const createPostRequest = new FormData();
 
-        createPostRequest.append('title', title);
-        createPostRequest.append('beginAt', startDate+"T12:00:00");
-        createPostRequest.append('finishAt', endDate+"T12:00:00");
-        createPostRequest.append('tags', JSON.stringify(tags));
-        
+        //experience는 title:content 쌍의 map 형식으로 전송
         const experiencesObj = {};
-        experiences.forEach(experience => {
+        experiences.forEach((experience) => {
             experiencesObj[experience.title] = experience.content;
         });
-        createPostRequest.append('experiences', JSON.stringify(experiencesObj));
 
-        const formDataEntries = createPostRequest.entries();
-        for (const [key, value] of formDataEntries) {
-        console.log(key, value);
+        //createPostRequst Dto 형식에 맞춤
+        const createPostRequest = {
+            title : title,
+            beginAt : startDate+"T12:00:00",
+            finishAt : endDate+"T12:00:00",
+            tags : tags,
+            experiences : experiencesObj
         }
-
+        
+        //formData에 추가
+        const formData = new FormData();
+        formData.append('createPostRequest', new Blob([JSON.stringify(createPostRequest)], {type: "application/json"}));
+      
         try {
-            const response = await axios.post('/api/v1/posts', createPostRequest, {
+            const response = await axios ({
+                method: 'post',
+                url: '/api/v1/posts',
+                data: formData,
                 headers: {
-                    'Content-Type': 'multipart/form-data',
-                  }
+                    'Content-Type': `multipart/form-data`, // Content-Type을 반드시 이렇게 하여야 한다.
+                  },
             });
-            
             console.log(response.data); // 서버로부터의 응답 데이터
+        
         } catch (error) {
-            console.error(error.response);
-        }
+            console.error('creat post 요청 중 오류가 발생했습니다.', error);
+        }   
     };
+
+
+    //파일 첨부
+    const fileInput = React.useRef(null);
+
+    //선택된 파일
+    const [selectedFiles, setSelectedFiles] = useState([]);
 
     const handleFileChange = event => {
         const files = Array.from(event.target.files);
@@ -92,18 +119,6 @@ const Write = () => {
         fileInput.current.click();
     };
 
-    // ExperienceForm 삭제
-    const handleRemoveExperience = index => {
-        const newExperiences = [...experiences];
-        newExperiences.splice(index, 1);
-        setExperiences(newExperiences);
-    };
-
-    const handleAddExperience = () => {
-        setExperiences([...experiences, { title: '', content: '' }]);
-        setShowAddButton(true);
-    };
-
     return (
         <div>
             <div className={styles.fixedHeader}>
@@ -111,7 +126,7 @@ const Write = () => {
                 <h1>소중한 경험을 기록해주세요 🥳</h1>
             </div>
             <div className={styles.writeContainer}>
-                <div className={styles.formContainer}>
+                <form className={styles.formContainer}  onSubmit={handleSubmit}>
                     <PostForm title={title} setTitle={setTitle}
                             startDate={startDate} setStartDate={setStartDate}
                             endDate={endDate} setEndDate={setEndDate}
@@ -168,9 +183,9 @@ const Write = () => {
                         </div>
                     )}
 
-                    <button className={styles.writeButton} onClick={handleSubmit}>글쓰기</button>
+                    <button className={styles.writeButton} type="submit">글쓰기</button>
                     <div className={styles.last}>PODA</div>
-                </div>
+                </form>
             </div>
         </div>
     );

--- a/src/routes/Write.js
+++ b/src/routes/Write.js
@@ -7,6 +7,8 @@ import axios from 'axios';
 
 
 const Write = () => {
+
+    //제목, 기간, tag
     const [title, setTitle] = useState('');
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
@@ -14,9 +16,7 @@ const Write = () => {
     const [abilityTags, setAbilityTags] = useState([]);
     const [stackTags, setStackTags] = useState([]);
 
-
-    /*내용 추가 버튼 show */
-    const [showAddButton, setShowAddButton] = useState(true);
+    //experiences 기본 질문 4개
     const [experiences, setExperiences] = useState([
         { title: '활동을 하게 된 동기를 기록해주세요.', content: '' },
         { title: '맡은 역할과 수행 내용을 기록해주세요.', content: '' },
@@ -31,19 +31,46 @@ const Write = () => {
         setExperiences(newExperiences);
     };
 
-
     //ExperienceForm 추가
-    const handleAddExperience = () => {
+    const handleAddExperience = e => {
+        e.preventDefault();
         setExperiences([...experiences, { title: '', content: '' }]);
-        setShowAddButton(true);
     };
     
-
-    //expereince update
+    //experience 변경 내용 저장
     const handleSaveExperience = (index, experience) => {
     const updatedExperiences = [...experiences];
     updatedExperiences[index] = experience;
     setExperiences(updatedExperiences);
+    };
+
+    //파일 첨부
+    const fileInput = React.useRef(null);
+
+    //선택된 파일
+    const [selectedFiles, setSelectedFiles] = useState([]);
+
+
+    //file 추가 버튼을 누를경우
+    const handleButtonClick = e => {
+        e.preventDefault();
+        fileInput.current.click();
+    };
+        
+    //파일을 추가할 경우
+    const handleFileChange = e => {
+        e.preventDefault();
+        const files = Array.from(e.target.files);
+        setSelectedFiles(prevSelectedFiles => [...prevSelectedFiles, ...files]);
+    };
+
+    //선택 파일을 선택 해제할 경우
+    const removeFile = index => {
+        setSelectedFiles(prevSelectedFiles => {
+        const updatedFiles = [...prevSelectedFiles];
+        updatedFiles.splice(index, 1);
+        return updatedFiles;
+        });
     };
 
 
@@ -86,7 +113,12 @@ const Write = () => {
         //formData에 추가
         const formData = new FormData();
         formData.append('createPostRequest', new Blob([JSON.stringify(createPostRequest)], {type: "application/json"}));
-      
+        
+         // 선택된 파일들을 formData에 리스트로 추가
+        selectedFiles.forEach((file, index) => {
+            formData.append('file', file);
+        });
+
         try {
             const response = await axios ({
                 method: 'post',
@@ -96,28 +128,13 @@ const Write = () => {
                     'Content-Type': `multipart/form-data`, // Content-Type을 반드시 이렇게 하여야 한다.
                   },
             });
+
             console.log(response.data); // 서버로부터의 응답 데이터
-        
         } catch (error) {
             console.error('creat post 요청 중 오류가 발생했습니다.', error);
         }   
     };
 
-
-    //파일 첨부
-    const fileInput = React.useRef(null);
-
-    //선택된 파일
-    const [selectedFiles, setSelectedFiles] = useState([]);
-
-    const handleFileChange = event => {
-        const files = Array.from(event.target.files);
-        setSelectedFiles(files);
-    };
-
-    const handleButtonClick = e => {
-        fileInput.current.click();
-    };
 
     return (
         <div>
@@ -126,7 +143,7 @@ const Write = () => {
                 <h1>소중한 경험을 기록해주세요 🥳</h1>
             </div>
             <div className={styles.writeContainer}>
-                <form className={styles.formContainer}  onSubmit={handleSubmit}>
+                <form className={styles.formContainer} onSubmit={handleSubmit}>
                     <PostForm title={title} setTitle={setTitle}
                             startDate={startDate} setStartDate={setStartDate}
                             endDate={endDate} setEndDate={setEndDate}
@@ -142,17 +159,15 @@ const Write = () => {
                             onRemove={() => handleRemoveExperience(index)}
                         />
                     ))}
-                    {showAddButton && (
-                        <div className={styles.add}>
-                            내용 추가하기
-                            <button
-                                className={styles.addButton}
-                                onClick={handleAddExperience}
-                            >
-                                +
-                            </button>
-                        </div>
-                    )}
+                    <div className={styles.add}>
+                        내용 추가하기
+                        <button
+                            className={styles.addButton}
+                            onClick={handleAddExperience}
+                        >
+                            +
+                        </button>
+                    </div>
 
                     <div className={styles.add}>
                         {' '}
@@ -173,11 +188,30 @@ const Write = () => {
                             style={{ display: 'none' }}
                         />
                     </div>
+
                     {selectedFiles.length > 0 && (
                         <div className={styles.fileList}>
-                            {selectedFiles.map((file, index) => (
+                            {selectedFiles.map((file, index) => ( 
                                 <div key={index} className={styles.fileItem}>
-                                    {file.name}
+                                    {file.type.includes('image/') && (
+                                       <div>
+                                            <img
+                                                src={URL.createObjectURL(file)}
+                                                alt={file.name}
+                                                className={styles.image}
+                                            />
+                                            <div className={styles.fileName}>{file.name}</div>
+                                        </div>
+                                    )}
+                                    {!file.type.includes('image/') && (
+                                        <div className={styles.fileName}>{file.name}</div>
+                                    )}
+                                    <button
+                                        className={styles.fileRemoveButton}
+                                        onClick={() => removeFile(index)}
+                                    >
+                                        X
+                                    </button>
                                 </div>
                             ))}
                         </div>

--- a/src/styles/Write.module.css
+++ b/src/styles/Write.module.css
@@ -238,16 +238,39 @@
     width: 100%;
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
     padding-bottom: 20px;
 }
 
 .fileItem {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     width: 100%;
-    padding: 10px;
     margin-bottom: 5px;
+}
+
+.fileName {
     background-color: #f7f7f7;
-    border-radius: 5px;
+    border-radius: 20px;
+    padding:10px;
+}
+
+.image {
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 20px;
+}
+
+.fileRemoveButton {
+    padding-left: 20px;
+    margin-right: 20px;
+    font-size: 15px;
+    width: 20px;
+    height: 20px;
+    border: none;
+    background-color: transparent;
+    color: #718096;
+    cursor: pointer;
 }
 
 /*글쓰기 버튼*/
@@ -262,7 +285,11 @@
     color: white;
     font-weight: 700;
     font-size: 20px;
+    transition: background-color 0.2s;
 }
+.writeButton:active {
+    background-color: #914ea6;
+  }
 
 
 /*임시 Footer..*/


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #16

## 📝 작업 내용
글쓰기 페이지를 api 와 연동하였습니다. 
createPostRequest DTO에 맞춰 formData에 추가하고, 첨부할 file의 list 또한 formData에 추가하여 axios를 이용하여 formData와 함께 post request를 보냅니다.
## 💭 주의 사항
글쓰기 버튼을 눌렀을 때, createPost가 제대로 실행되었다면 해당 게시글의 detail 페이지로 이동하도록 해야합니다. Detail페이지와 api 연동 후 추후 추가하겠습니다.
## 💡 리뷰 포인트
