### PR TITLE
[FEAT] 단일 조회 페이지 API 연동

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,65 +13,18 @@ import {
 
 function App() {
     const [isLoggedIn, setIsLoggedIn] = useState(true);
-    const [posts, setPosts]= useState( [
-        {
-            id:1,
-            title: '교내 해커톤',
-            startDate: '2022-06-01',
-            endDate: '2022-06-02',
-            tags: {
-                '관련 직무': ['#백엔드'],
-                '핵심 역량': ['#협동', '#협업'],
-                '사용한 기술': ['#SpringBoot', '#Docker'],
-              },
-            file: 
-            //임시! 나중에 file형식으로 가져오면됨
-                []
-            
-        },
-        {
-            id:2,
-            title: '포다포다',
-            startDate: '2022.06.01',
-            endDate: '2022.06.02',
-            tags: {
-                '관련 직무': ['#백엔드'],
-                '핵심 역량': ['#협동', '#협업'],
-                '사용한 기술': ['#SpringBoot', '#Docker'],
-              },
-            file: 
-            //임시! 나중에 file형식으로 가져오면됨
-                ['최종보고서.doc','PODA.png']
-        },
-        {
-            id:3,
-            title: '글 3',
-            startDate: '2022.06.02',
-            endDate: '2022.06.03',
-            tags: {
-                '관련 직무': ['#백엔드'],
-                '핵심 역량': ['#협동', '#협업'],
-                '사용한 기술': ['#SpringBoot', '#Docker'],
-              },
-            file: 
-            //임시! 나중에 file형식으로 가져오면됨
-                ['최종보고서.doc','PODA.png']
-        },
-
-        // ...
-    ]);
-
-    const handleDeletePost = (postId) => {
-        const updatedPosts = posts.filter((post) => post.id !== postId);
-        setPosts(updatedPosts);
-      };
+    
+    // const handleDeletePost = (postId) => {
+    //     const updatedPosts = posts.filter((post) => post.id !== postId);
+    //     setPosts(updatedPosts);
+    //   };
 
     return <Router>
         <Routes>
-            <Route path="/" element={isLoggedIn ? <Home posts={posts}/> : <Navigate to="/login" />} />
+            <Route path="/" element={isLoggedIn ? <Home/> : <Navigate to="/login" />} />
             <Route path="/login" element={<Login />} />
             <Route path="/write" element={<Write />} />
-            <Route path="/posts/:id" element={<PostDetail posts={posts} onDeletePost={handleDeletePost}/>} />
+            <Route path="/posts/:postId" element={<PostDetail />} />
             <Route path="/mypage" element={<MyPage />} />
         </Routes>
     </Router>

--- a/src/components/ExCreateForm.js
+++ b/src/components/ExCreateForm.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styles from '../styles/Detail.module.css';
 
 
-const ExCreateForm = ({ experiences, setExperiences,onAddExperience }) => {
+const ExCreateForm = ({onAddExperience }) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
 
@@ -10,7 +10,6 @@ const ExCreateForm = ({ experiences, setExperiences,onAddExperience }) => {
 
   const handleSave = () => {
     const newExperience = {
-      experienceId: experiences.length + 1,
       title: title,
       content: content,
     };

--- a/src/components/ExUpdateForm.js
+++ b/src/components/ExUpdateForm.js
@@ -1,25 +1,27 @@
-import React from 'react';
+import React,{useState} from 'react';
 
 import styles from '../styles/Detail.module.css';
 
 
 //단일조회에서 exprience update를 위한 form
-const ExUpdateForm = ({ title, setTitle, content, setContent, onUpdate }) => {
-    const handleTitleChange = event => {
-        const newTitle = event.target.value;
-        setTitle(newTitle);
-    };
-
-    const handleTextChange = event => {
-        const newText = event.target.value;
-        setContent(newText);
-    };
-
+const ExUpdateForm = ({ expereince, onUpdate }) => {
+    const [title, setTitle] = useState(expereince.title);
+    const [content, setContent] = useState(expereince.content);
+  
+  
     const characterCount = content.length;
 
     const handleUpdate = () => {
-        onUpdate(); // 부모 컴포넌트로 저장 요청
-    };
+        const updateExperience = {
+          experienceId: expereince.experienceId,
+          title: title,
+          content: content,
+        };
+        
+        onUpdate(updateExperience);
+        setTitle('');
+        setContent('');
+      };
 
     return (
         <div className={styles.exContainer}>
@@ -29,7 +31,7 @@ const ExUpdateForm = ({ title, setTitle, content, setContent, onUpdate }) => {
                         className={styles.inputTitle}
                         type="text"
                         placeholder="제목을 입력하세요"
-                        onChange={handleTitleChange}
+                        onChange={(e) => setTitle(e.target.value)}
                         value={title}
                     />
                     <div className={styles.characterCount}>
@@ -43,7 +45,7 @@ const ExUpdateForm = ({ title, setTitle, content, setContent, onUpdate }) => {
             <textarea
                 className={styles.textContainer}
                 value={content}
-                onChange={handleTextChange}
+                onChange={(e) => setContent(e.target.value)}
                 placeholder="내용"
             />
         </div>

--- a/src/components/ExperienceContainer.js
+++ b/src/components/ExperienceContainer.js
@@ -3,10 +3,8 @@ import styles from '../styles/Detail.module.css';
 import ExUpdateForm from './ExUpdateForm';
 
 //단일 experience를 담은 container
-const ExperienceContainer = ({ experienceId, title, content, onDelete }) => {
+const ExperienceContainer = ({ experience,onUpdate,onDelete }) => {
     const [isEditing, setIsEditing] = useState(false);
-    const [exTitle, setExTitle] = useState(title);
-    const [exContent, setExContent] = useState(content);
 
     //수정버튼 눌렀을 때
     const handleEditClick = () => {
@@ -14,31 +12,29 @@ const ExperienceContainer = ({ experienceId, title, content, onDelete }) => {
     };
 
     //저장버튼 눌렀을 때
-    const handleSaveClick = () => {
+    const handleSaveClick = (updateExperience) => {
+        onUpdate(updateExperience);
         setIsEditing(false);
     };
     //삭제
     const handleDeleteClick = () => {
-        onDelete(experienceId);
+        onDelete(experience.experienceId);
     };
 
     return (
         <div style={{ width: '100%' }}>
             {isEditing ? (
                 <ExUpdateForm
-                    title={exTitle}
-                    setTitle={setExTitle}
-                    content={exContent}
-                    setContent={setExContent}
+                    expereince={experience}
                     onUpdate={handleSaveClick}
                 />
             ) : (
                 <div className={styles.exContainer}>
                     <div className={styles.titleContainer}>
                         <div className={styles.titleCharacterContainer}>
-                            <div className={styles.exTitle}>{exTitle}</div>
+                            <div className={styles.exTitle}>{experience.title}</div>
                             <div className={styles.characterCount}>
-                                {exContent.length}자
+                                {experience.content.length}자
                             </div>
                         </div>
                         <div className={styles.buttonContainer}>
@@ -56,7 +52,7 @@ const ExperienceContainer = ({ experienceId, title, content, onDelete }) => {
                             </button>
                         </div>
                     </div>
-                    <div className={styles.textContainer}>{exContent}</div>
+                    <div className={styles.textContainer}>{experience.content}</div>
                 </div>
             )}
         </div>

--- a/src/components/PostUpdateModal.js
+++ b/src/components/PostUpdateModal.js
@@ -1,53 +1,31 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styles from '../styles/Modal.module.css';
 import TagInput from './TagInput';
 
 
 //단일 조회화면에서 Post 정보들을 수정하는 Modal
 const PostUpdateModal = ({
-    title,
-    setTitle,
-    startDate,
-    setStartDate,
-    endDate,
-    setEndDate,
-    jobTags,
-    setJobTags,
-    abilityTags,
-    setAbilityTags,
-    stackTags,
-    setStackTags,
+    initData,
     onUpdate,
-    setModalOpen,
-}) => {
+    setModalOpen }) => {
     
+    const [updatedData, setUpdatedData] = useState(initData);
+
     // 모달 끄기
     const closeModal = () => {
-        // 데이터를 업데이트하고 onUpdate 함수 호출
-        const updatedData = {
-            title,
-            startDate,
-            endDate,
-            jobTags,
-            abilityTags,
-            stackTags,
-        };
-        onUpdate(updatedData);
-
-        setModalOpen(false);
+      onUpdate(updatedData);
+      setModalOpen(false);
     };
+  
 
-    const handleTitleChange = e => {
-        setTitle(e.target.value);
+    //수정된 field만 업데이트
+    const handleInputChange = (field, value) => {
+      setUpdatedData(prevData => ({
+        ...prevData,
+        [field]: value,
+      }));
     };
-
-    const handleStartDateChange = e => {
-        setStartDate(e.target.value);
-    };
-
-    const handleEndDateChange = e => {
-        setEndDate(e.target.value);
-    };
+  
 
     return (
         <div className={styles.modalBox}>
@@ -62,8 +40,9 @@ const PostUpdateModal = ({
                             <input
                                 className={styles.inputText}
                                 type="text"
-                                value={title}
-                                onChange={handleTitleChange}
+                                value={updatedData.title}
+                                required
+                                onChange={e => handleInputChange('title', e.target.value)}
                                 placeholder="제목을 입력해주세요"
                             />
                         </div>
@@ -74,34 +53,34 @@ const PostUpdateModal = ({
                                     <img src="/right.png" alt="오른쪽 화살표" />
                                     <input
                                         type="date"
-                                        value={startDate}
-                                        onChange={handleStartDateChange}
+                                        value={updatedData.startDate}
+                                        onChange={e => handleInputChange('startDate', e.target.value)}
                                     />
                                 </div>
                                 <div className={styles.date}>
                                     <img src="/left.png" alt="왼쪽 화살표" />
                                     <input
                                         type="date"
-                                        value={endDate}
-                                        onChange={handleEndDateChange}
+                                        value={updatedData.endDate}
+                                        onChange={e => handleInputChange('endDate', e.target.value)}
                                     />
                                 </div>
                             </div>
                         </div>
                         <TagInput
-                            tags={jobTags}
-                            setTags={setJobTags}
+                            tags={updatedData.jobTags}
+                            setTags={tags => handleInputChange('jobTags', tags)}
                             tagType="관련 직무"
                         />
                         <TagInput
-                            tags={abilityTags}
-                            setTags={setAbilityTags}
-                            tagType="키워드"
+                            tags={updatedData.abilityTags}
+                            setTags={tags => handleInputChange('abilityTags', tags)}
+                            tagType="핵심 역량"
                         />
                         <TagInput
-                            tags={stackTags}
-                            setTags={setStackTags}
-                            tagType="사용 기술"
+                            tags={updatedData.stackTags}
+                            setTags={tags => handleInputChange('stackTags', tags)}
+                            tagType="사용한 기술"
                         />
                     </div>
                 </div>

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -142,8 +142,8 @@ const Home = () => {
                     <ul className={styles.postList}>
                     {selectedTags.length === 0
                     ? posts.map((post) => (
-                        <div key={post.id} className={styles.postListli}>
-                            <Link to={`/posts/${post.id}`}>
+                        <div key={post.postId} className={styles.postListli}>
+                            <Link to={`/posts/${post.postId}`}>
                             <li>
                                 <div className={styles.titleDuration}>
                                 <h3>{post.title}</h3>

--- a/src/routes/PostDetail.js
+++ b/src/routes/PostDetail.js
@@ -314,6 +314,11 @@ const PostDetail = () => {
            });
            const data = await response.json();
            console.log(data);
+           
+           const getResponse = await fetch(`/api/v1/posts/${postId}/files`);
+           const getData = await getResponse.json();
+           console.log(getData);
+           setFiles(getData);           
 
        } catch (error) {
            console.error('파일 update 중 오류가 발생했습니다.', error);
@@ -466,7 +471,8 @@ const PostDetail = () => {
                             }
                         })}
                         </div>
-                        <div className={styles.add}>
+                    </div>
+                    <div className={styles.add}>
                             파일 추가하기
                             <button
                             className={styles.addButton}
@@ -484,7 +490,6 @@ const PostDetail = () => {
                             +
                             </button>
                         </div>
-                    </div>
 
                     <a
                         href="https://www.flaticon.com/kr/free-icons/"

--- a/src/routes/PostDetail.js
+++ b/src/routes/PostDetail.js
@@ -6,6 +6,7 @@ import styles from '../styles/Detail.module.css';
 import ExperienceContainer from '../components/ExperienceContainer';
 import PostUpdateModal from '../components/PostUpdateModal';
 import ExCreateForm from '../components/ExCreateForm';
+
 const PostDetail = () => {
 
     //url 파라미터로 id 찾아옴
@@ -24,9 +25,7 @@ const PostDetail = () => {
     const [experiences, setExperiences] = useState([]);
     //file
     const fileInput = React.useRef(null);
-    const [selectedFiles, setSelectedFiles] = useState([]);
-
-
+    const [files,setFiles] = useState([]);
     //api get요청으로 orderBy에 따라 posts목록 받아오기
     useEffect(() => {
         fetch(`/api/v1/posts/${postId}`)
@@ -60,7 +59,7 @@ const PostDetail = () => {
                 setJobTags(jobTags);
                 setAbilityTags(abilityTags);
                 setStackTags(stackTags);
-                setSelectedFiles(files);
+                setFiles(files);
             })
             .catch(error => {
             console.error('post 데이터를 가져오는 동안 오류가 발생했습니다.', error);
@@ -277,19 +276,43 @@ const PostDetail = () => {
         deleteExperienceApi(experienceId);
     };
 
-    const handleFileChange = event => {
-        const files = Array.from(event.target.files);
-        setSelectedFiles(files);
-    };
+    //기존 file 삭제
+    const handleDeleteFile = e => {
+        e.preventDefault();
+    }
 
+    //file 추가 버튼을 누를경우
     const handleButtonClick = e => {
         fileInput.current.click();
     };
-
-    const handleDeleteFile = () => {
-        setSelectedFiles([]);
+        
+    //파일을 추가할 경우
+    const handleFileChange = e => {
+        const selectedfiles = Array.from(e.target.files);
+        uploadFilesApi(selectedfiles);
     };
-    
+
+
+    //파일 업로드 api 요청
+    const uploadFilesApi = async(selectedfiles) => {
+         //formData에 추가
+       const formData = new FormData();
+        // 선택된 파일들을 formData에 리스트로 추가
+        selectedfiles.forEach((file) => {
+            formData.append('file', file);
+        });
+       try {
+           const response = await fetch(`/api/v1/posts/${postId}/files`, {
+               method: 'PUT',
+               body: formData,
+           });
+           const data = await response.json();
+           console.log(data);
+
+       } catch (error) {
+           console.error('파일 update 중 오류가 발생했습니다.', error);
+       }
+    }
 
 
 
@@ -385,42 +408,24 @@ const PostDetail = () => {
                         />
                     )}
 
-                    {selectedFiles.length > 0 ? (
-                    <div className={styles.exContainer}>
-                        <div className={styles.titleContainer}>
-                            <div className={styles.exTitle}>파일</div>
-                            <div className={styles.buttonContainer}>
-                                <button
-                                className={styles.deleteButton}
-                                onClick={handleDeleteFile}
-                                >
-                                <span>삭제</span>
-                                </button>
-                                <button
-                                className={styles.updateButton}
-                                onClick={handleButtonClick}
-                                >
-                                수정
-                                </button>
-                                <input
-                                id="file-upload"
-                                type="file"
-                                ref={fileInput}
-                                multiple={true}
-                                onChange={handleFileChange}
-                                style={{ display: 'none' }}
-                                />
-                            </div>
-                        </div>
 
+                    <div className={styles.exContainer}>
                         <div className={styles.fileList}>
-                        {selectedFiles.map((file, index) => {
+                        {files.map((file, index) => {
                             if (file.filePath.endsWith('.png') || file.filePath.endsWith('.jpg') || file.filePath.endsWith('.jpeg') || file.filePath.endsWith('.gif')) {
                             return (
                                 <div
                                 key={index}
                                 className={styles.fileContainer}
                                 >
+                                <div className={styles.buttonContainer}>
+                                    <button
+                                    className={styles.deleteButton}
+                                    onClick={handleDeleteFile}
+                                    >
+                                    <span>삭제</span>
+                                    </button>
+                                </div>
                                 <img
                                     src={file.filePath}
                                     alt={file.fileName}
@@ -435,6 +440,14 @@ const PostDetail = () => {
                                 key={index}
                                 className={styles.fileContainer}
                                 >
+                                <div className={styles.buttonContainer}>
+                                    <button
+                                    className={styles.deleteButton}
+                                    onClick={handleDeleteFile}
+                                    >
+                                    <span>삭제</span>
+                                    </button>
+                                </div>
                                 <a
                                     href={file.filePath}
                                     target="_blank"
@@ -448,27 +461,25 @@ const PostDetail = () => {
                             }
                         })}
                         </div>
+                        <div className={styles.add}>
+                            파일 추가하기
+                            <button
+                            className={styles.addButton}
+                            onClick={handleButtonClick}
+                            >
+                            <input
+                            id="file-upload"
+                            type="file"
+                            ref={fileInput}
+                            multiple={true}
+                            onChange={handleFileChange}
+                            className={styles.addButton}
+                            style={{ display: 'none' }}
+                            />
+                            +
+                            </button>
+                        </div>
                     </div>
-                    ) : (
-                    <div className={styles.add}>
-                        파일 첨부하기
-                        <button
-                        className={styles.addButton}
-                        onClick={handleButtonClick}
-                        >
-                        +
-                        </button>
-                        <input
-                        id="file-upload"
-                        type="file"
-                        ref={fileInput}
-                        multiple={true}
-                        onChange={handleFileChange}
-                        className={styles.addButton}
-                        style={{ display: 'none' }}
-                        />
-                    </div>
-                    )}
 
                     <a
                         href="https://www.flaticon.com/kr/free-icons/"

--- a/src/routes/PostDetail.js
+++ b/src/routes/PostDetail.js
@@ -187,6 +187,13 @@ const PostDetail = () => {
            const data = await response.json();
            // 업데이트에 대한 응답 처리
            console.log(data);
+           const newEx = {
+            experienceId: data.result.experienceId,
+            title :newExperience.title,
+            content: newExperience.content
+           }
+           setExperiences( prev => [...prev, newEx]);
+           
        } catch (error) {
            console.error('경험 추가 중 오류가 발생했습니다.', error);
        }
@@ -240,7 +247,6 @@ const PostDetail = () => {
 
     //경험 추가
     const handleAddExperience = newExperience => {
-        setExperiences([...experiences, newExperience]);
 
         //api 요청
         createExperienceApi(postId, newExperience);
@@ -403,7 +409,6 @@ const PostDetail = () => {
                         </div>
                     ) : (
                         <ExCreateForm
-                            experiences={experiences}
                             onAddExperience={handleAddExperience}
                         />
                     )}

--- a/src/routes/PostDetail.js
+++ b/src/routes/PostDetail.js
@@ -37,11 +37,7 @@ const PostDetail = () => {
                 setStartDate(data.result.beginAt);
                 setEndDate(data.result.finishAt);
                 // 경험 데이터 추출
-                const experiences = getExperienceResponses.map(experience => ({
-                    experienceId: experience.experienceId,
-                    title: experience.title,
-                    content: experience.content
-                }));
+                const experiences = getExperienceResponses;
 
                 // 태그 데이터 추출
                 const jobTags = getTagResponses.find(tag => tag.tagType === "JOB")?.tagName || [];
@@ -49,10 +45,7 @@ const PostDetail = () => {
                 const stackTags = getTagResponses.find(tag => tag.tagType === "STACK")?.tagName || [];
 
                 // 파일 데이터 추출
-                const files = getFileResponses.map(file => ({
-                    fileName: file.fileName,
-                    filePath: file.filePath
-                }));
+                const files = getFileResponses;
 
                 // 추출한 데이터를 상태에 설정
                 setExperiences(experiences);
@@ -283,8 +276,12 @@ const PostDetail = () => {
     };
 
     //기존 file 삭제
-    const handleDeleteFile = e => {
-        e.preventDefault();
+    const handleDeleteFile = fileId => {
+        const updatedFiles = files.filter(
+            file => file.fileId !==fileId
+        );
+        setFiles(updatedFiles);
+        deleteFileApi(fileId);
     }
 
     //file 추가 버튼을 누를경우
@@ -318,13 +315,28 @@ const PostDetail = () => {
            const getResponse = await fetch(`/api/v1/posts/${postId}/files`);
            const getData = await getResponse.json();
            console.log(getData);
-           setFiles(getData);           
+           setFiles(getData.result);           
 
        } catch (error) {
            console.error('파일 update 중 오류가 발생했습니다.', error);
        }
     }
 
+    const deleteFileApi = async(fileId) => {
+        try {
+            const response = await fetch(`/api/v1/files/${fileId}`, {
+              method: 'DELETE',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            });
+            const data = await response.json();
+            // 삭제에 대한 응답 처리
+            console.log(data);
+          } catch (error) {
+            console.error('파일 삭제 중 오류가 발생했습니다.', error);
+          }
+    }
 
 
     return (
@@ -431,7 +443,7 @@ const PostDetail = () => {
                                 <div className={styles.buttonContainer}>
                                     <button
                                     className={styles.deleteButton}
-                                    onClick={handleDeleteFile}
+                                    onClick={() => handleDeleteFile(file.fileId)}
                                     >
                                     <span>삭제</span>
                                     </button>
@@ -453,7 +465,7 @@ const PostDetail = () => {
                                 <div className={styles.buttonContainer}>
                                     <button
                                     className={styles.deleteButton}
-                                    onClick={handleDeleteFile}
+                                    onClick={() => handleDeleteFile(file.fileId)}
                                     >
                                     <span>삭제</span>
                                     </button>

--- a/src/routes/PostDetail.js
+++ b/src/routes/PostDetail.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState,useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
@@ -6,44 +6,168 @@ import styles from '../styles/Detail.module.css';
 import ExperienceContainer from '../components/ExperienceContainer';
 import PostUpdateModal from '../components/PostUpdateModal';
 import ExCreateForm from '../components/ExCreateForm';
-const PostDetail = ({ posts, onDeletePost }) => {
+const PostDetail = () => {
     //url 파라미터로 id 찾아옴
-    const { id } = useParams();
+    const { postId } = useParams();
     const navigate = useNavigate();
-    const post = posts.find(post => post.id === Number(id));
+    //post
+  
+    const [title, setTitle] = useState('');
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
+    const [jobTags, setJobTags] = useState([]);
+    const [abilityTags, setAbilityTags] = useState([]);
+    const [stackTags, setStackTags] = useState([]);
+
+    //experience
+    const [experiences, setExperiences] = useState([]);
+    //file
+    const fileInput = React.useRef(null);
+    const [selectedFiles, setSelectedFiles] = useState([]);
+
+
+    //api get요청으로 orderBy에 따라 posts목록 받아오기
+    useEffect(() => {
+        fetch(`/api/v1/posts/${postId}`)
+            .then(response => response.json())
+            .then(data => {
+                const { getExperienceResponses, getTagResponses, getFileResponses } = data.result;
+                
+                setTitle(data.result.title);
+                setStartDate(data.result.beginAt);
+                setEndDate(data.result.finishAt);
+                // 경험 데이터 추출
+                const experiences = getExperienceResponses.map(experience => ({
+                    experienceId: experience.experienceId,
+                    title: experience.title,
+                    content: experience.content
+                }));
+
+                // 태그 데이터 추출
+                const jobTags = getTagResponses.find(tag => tag.tagType === "JOB")?.tagName || [];
+                const abilityTags = getTagResponses.find(tag => tag.tagType === "ABILITY")?.tagName || [];
+                const stackTags = getTagResponses.find(tag => tag.tagType === "STACK")?.tagName || [];
+
+                // 파일 데이터 추출
+                const files = getFileResponses.map(file => ({
+                    fileName: file.fileName,
+                    filePath: file.filePath
+                }));
+
+                // 추출한 데이터를 상태에 설정
+                setExperiences(experiences);
+                setJobTags(jobTags);
+                setAbilityTags(abilityTags);
+                setStackTags(stackTags);
+                setSelectedFiles(files);
+            })
+            .catch(error => {
+            console.error('post 데이터를 가져오는 동안 오류가 발생했습니다.', error);
+            });
+        },[postId]
+    );
+        
+    const deletePost = async (postId) => {
+        try {
+          const response = await fetch(`/api/v1/posts/${postId}`, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          });
+          const data = await response.json();
+          // 삭제에 대한 응답 처리
+          console.log(data);
+        } catch (error) {
+          console.error('게시물 삭제 중 오류가 발생했습니다.', error);
+        }
+    };
 
     //삭제
-    const handleDeleteClick = () => {
-        onDeletePost(Number(id));
+    const handleDeleteClick = (postId) => {
+        deletePost(postId);
         navigate('/');
     };
 
     //modal
     const [modalOpen, setModalOpen] = useState(false);
 
-    //post
-    const [title, setTitle] = useState(post.title);
-    const [startDate, setStartDate] = useState(post.startDate);
-    const [endDate, setEndDate] = useState(post.endDate);
-    const [jobTags, setJobTags] = useState(post.tags['관련 직무']);
-    const [abilityTags, setAbilityTags] = useState(post.tags['핵심 역량']);
-    const [stackTags, setStackTags] = useState(post.tags['사용한 기술']);
+    // 모달창 노출
+    const showModal = () => {
+        setModalOpen(true);
+    };
 
-    //experience
-    const [experiences, setExperiences] = useState([
-        {
-            experienceId: 1,
-            title: '활동을 하게 된 동기를 기록해주세요.',
-            content: 'Content 1',
-        },
-        {
-            experienceId: 2,
-            title: '맡은 역할과 수행 내용을 기록해주세요.',
-            content: 'Content 2',
-        },
-        // ... 다른 experiences 데이터
-    ]);
+    //api에 post update 요청
+    const updatePost = async (postId, updatedData) => {
+         //createTagRequest 형식에 맞춤
+         const tags = [  
+            {
+                tagType: 'Job',
+                tagName: updatedData.jobTags
+            },
+            {
+                tagType: 'Stack',
+                tagName: updatedData.stackTags
+            },
+            {
+                tagType: 'Ability',
+                tagName: updatedData.abilityTags
+            }
+        ];
+        
+        // 필드가 비어있는지 확인
+        if (updatedData.startDate === '' || updatedData.endDate === '') {
+            alert('기간을 선택해주세요.'); 
+            return;
+        }
+        //createPostRequst Dto 형식에 맞춤
+        const updatePostRequest = {
+            title : updatedData.title,
+            beginAt : updatedData.startDate+"T12:00:00",
+            finishAt : updatedData.endDate+"T12:00:00",
+            tags : tags,
+        }
+        //formData에 추가
+        const formData = new FormData();
+        formData.append('updatePostRequest', new Blob([JSON.stringify(updatePostRequest)], {type: "application/json"}));
 
+        try {
+            const response = await fetch(`/api/v1/posts/${postId}`, {
+                method: 'PUT',
+                body: formData,
+            });
+            const data = await response.json();
+            // 업데이트에 대한 응답 처리
+            console.log(data);
+        } catch (error) {
+            console.error('게시물 업데이트 중 오류가 발생했습니다.', error);
+        }
+    };
+
+    //postUPdateModal에 전달해줄 초기 데이터
+    const initData = {
+        title: title,
+        startDate: startDate,
+        endDate: endDate,
+        jobTags: jobTags,
+        abilityTags: abilityTags,
+        stackTags: stackTags
+    }
+
+    // 업데이트 핸들러
+    const handleUpdate = updatedData => {
+        setTitle(updatedData.title); // title 상태 업데이트 예시
+        setStartDate(updatedData.startDate);
+        setEndDate(updatedData.endDate);
+        setJobTags(updatedData.jobTags);
+        setAbilityTags(updatedData.abilityTags);
+        setStackTags(updatedData.stackTags);
+
+        updatePost(postId,updatedData);
+    };
+
+
+    
     //경험 추가 form 보이기
     const [showForm, setShowForm] = useState(false);
 
@@ -61,25 +185,6 @@ const PostDetail = ({ posts, onDeletePost }) => {
         setExperiences(updatedExperiences);
     };
 
-    // 모달창 노출
-    const showModal = () => {
-        setModalOpen(true);
-    };
-
-    // 업데이트 핸들러
-    const handleUpdate = updatedData => {
-        setTitle(updatedData.title); // title 상태 업데이트 예시
-        setStartDate(updatedData.startDate);
-        setEndDate(updatedData.endDate);
-        setJobTags(updatedData.jobTags);
-        setAbilityTags(updatedData.abilityTags);
-        setStackTags(updatedData.stackTags);
-    };
-
-    //file
-    const fileInput = React.useRef(null);
-    const [selectedFiles, setSelectedFiles] = useState(post.file);
-
     const handleFileChange = event => {
         const files = Array.from(event.target.files);
         setSelectedFiles(files);
@@ -93,10 +198,6 @@ const PostDetail = ({ posts, onDeletePost }) => {
     };
 
 
-    //id로 post를 찾지 못했을 때
-    if (!post) {
-        return <div>글을 찾을 수 없습니다.</div>;
-    }
 
     return (
         <div>
@@ -110,7 +211,7 @@ const PostDetail = ({ posts, onDeletePost }) => {
                             <h1 className={styles.title}>{title}</h1>
                             <button
                                 className={styles.postDelete}
-                                onClick={handleDeleteClick}
+                                onClick={() => handleDeleteClick(postId)}
                             >
                                 글 삭제
                             </button>
@@ -122,18 +223,7 @@ const PostDetail = ({ posts, onDeletePost }) => {
                             />
                             {modalOpen && (
                                 <PostUpdateModal
-                                    title={title}
-                                    setTitle={setTitle}
-                                    startDate={startDate}
-                                    setStartDate={setStartDate}
-                                    endDate={endDate}
-                                    setEndDate={setEndDate}
-                                    jobTags={jobTags}
-                                    setJobTags={setJobTags}
-                                    abilityTags={abilityTags}
-                                    setAbilityTags={setAbilityTags}
-                                    stackTags={stackTags}
-                                    setStackTags={setStackTags}
+                                   initData={initData}
                                     onUpdate={handleUpdate}
                                     setModalOpen={setModalOpen}
                                 />
@@ -204,79 +294,90 @@ const PostDetail = ({ posts, onDeletePost }) => {
                     )}
 
                     {selectedFiles.length > 0 ? (
-                        <div className={styles.exContainer}>
-                            <div className={styles.titleContainer}>
-                                <div className={styles.exTitle}>파일</div>
-                                <div className={styles.buttonContainer}>
-                                    <button
-                                        className={styles.deleteButton}
-                                        onClick={handleDeleteFile}
-                                    >
-                                        <span>삭제</span>
-                                    </button>
-                                    <button
-                                        className={styles.updateButton}
-                                        onClick={handleButtonClick}
-                                    >
-                                        수정
-                                    </button>
-                                    <input
-                                        id="file-upload"
-                                        type="file"
-                                        ref={fileInput}
-                                        multiple={true}
-                                        onChange={handleFileChange}
-                                        style={{ display: 'none' }}
-                                    />
-                                </div>
-                            </div>
-
-                            {selectedFiles.map((file, index) => {
-                                if (file.type === 'image/png') {
-                                    return (
-                                        <div
-                                            key={index}
-                                            className={styles.fileContainer}
-                                        >
-                                            <img
-                                                src={URL.createObjectURL(file)}
-                                                alt={file.name}
-                                                className={styles.image}
-                                            />
-                                        </div>
-                                    );
-                                } else {
-                                    return (
-                                        <div
-                                            key={index}
-                                            className={styles.fileContainer}
-                                        >
-                                            {file.name}
-                                        </div>
-                                    );
-                                }
-                            })}
-                        </div>
-                    ) : (
-                        <div className={styles.add}>
-                            파일 첨부하기
-                            <button
-                                className={styles.addButton}
+                    <div className={styles.exContainer}>
+                        <div className={styles.titleContainer}>
+                            <div className={styles.exTitle}>파일</div>
+                            <div className={styles.buttonContainer}>
+                                <button
+                                className={styles.deleteButton}
+                                onClick={handleDeleteFile}
+                                >
+                                <span>삭제</span>
+                                </button>
+                                <button
+                                className={styles.updateButton}
                                 onClick={handleButtonClick}
-                            >
-                                +
-                            </button>
-                            <input
+                                >
+                                수정
+                                </button>
+                                <input
                                 id="file-upload"
                                 type="file"
                                 ref={fileInput}
                                 multiple={true}
                                 onChange={handleFileChange}
-                                className={styles.addButton}
                                 style={{ display: 'none' }}
-                            />
+                                />
+                            </div>
                         </div>
+
+                        <div className={styles.fileList}>
+                        {selectedFiles.map((file, index) => {
+                            if (file.filePath.endsWith('.png') || file.filePath.endsWith('.jpg') || file.filePath.endsWith('.jpeg') || file.filePath.endsWith('.gif')) {
+                            return (
+                                <div
+                                key={index}
+                                className={styles.fileContainer}
+                                >
+                                <img
+                                    src={file.filePath}
+                                    alt={file.fileName}
+                                    className={styles.image}
+                                />
+                                <div className={styles.fileName}>{file.fileName}</div>
+                                </div>
+                            );
+                            } else {
+                            return (
+                                <div
+                                key={index}
+                                className={styles.fileContainer}
+                                >
+                                <a
+                                    href={file.filePath}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className={styles.fileName}
+                                >
+                                    {file.fileName}
+                                </a>
+                                </div>
+                            );
+                            }
+                        })}
+                        </div>
+                    </div>
+                    ) : (
+                    <div className={styles.add}>
+                        파일 첨부하기
+                        <button
+                        className={styles.addButton}
+                        onClick={handleButtonClick}
+                        >
+                        +
+                        </button>
+                        <input
+                        id="file-upload"
+                        type="file"
+                        ref={fileInput}
+                        multiple={true}
+                        onChange={handleFileChange}
+                        className={styles.addButton}
+                        style={{ display: 'none' }}
+                        />
+                    </div>
                     )}
+
                     <a
                         href="https://www.flaticon.com/kr/free-icons/"
                         title="기어 아이콘"

--- a/src/styles/Detail.module.css
+++ b/src/styles/Detail.module.css
@@ -210,6 +210,7 @@
 .image {
     max-width: 100%;
     max-height: 100%;
+    padding-top: 5px;
 }
 
 .add {

--- a/src/styles/Detail.module.css
+++ b/src/styles/Detail.module.css
@@ -216,7 +216,6 @@
 .add {
     width: 100%;
     padding: 10px;
-    margin-top: 20px;
     font-weight: 700;
     font-size: 20px;
 }


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #18 

## 📝 작업 내용
단일 조회 페이지의 조회, 수정, 삭제 API 들을 연동하였습니다.
## 💭 주의 사항
대대적인 리팩토링이 필요합니다.......... 
css도 StyleComponent로 수정하고 컴포넌트도 분리하고 API 호출도 분리가 필요합니다. 상태 관리도 최적화해야합니다........
추가 공부가 필요합니다.,....
## 💡 리뷰 포인트
